### PR TITLE
added the ability to select a package format

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -7,7 +7,8 @@ class HomesController < ApplicationController
     @cost=params[:cost].to_f
     @packaging=params[:packaging]
 
-    @number_of_servings = Constants.calculate_servings(@abv, @volume, @unit)
+    @calculated_volume = Constants.calculate_volume(@packaging, @volume, @unit)
+    @number_of_servings = Constants.calculate_servings(@abv, @calculated_volume)
     @cost_per_serving = Constants.calculate_cost_per_serving(@cost, @number_of_servings)
 
     @wine_cost = Constants.calculate_wine_cost(@cost_per_serving)

--- a/app/models/constants.rb
+++ b/app/models/constants.rb
@@ -19,16 +19,35 @@ module Constants
   SERVINGS_PER_6PK_12OZ_OF_BEER = (BOTTLE_12OZ*UNITS_IN_6PK)/BOTTLE_12OZ
   SERVINGS_PER_4PK_16OZ_OF_BEER = (CAN_16OZ*UNITS_IN_4PK)/BOTTLE_12OZ
 
-  def calculate_servings(in_abv, in_volume, in_unit)
+  DISPLAY_PACKAGING = {
+    "750ml" => "750ml bottle",
+    "4pk-16oz" => "4-pk of 16oz cans",
+    "6pk-12oz" => "6-pk of 12oz bottles"
+  }
 
-    if in_unit == "ml"
-      volume = in_volume*ML_TO_OZ_CONVERSION
+  def calculate_volume(in_packaging, in_volume, in_unit)
+
+    case in_packaging
+    when "750ml"
+      volume = BOTTLE_750ML*ML_TO_OZ_CONVERSION
+    when "4pk-16oz"
+      volume = UNITS_IN_4PK*CAN_16OZ
+    when "6pk-12oz"
+      volume = UNITS_IN_6PK*BOTTLE_12OZ
     else
-      volume = in_volume
+      if in_unit == "ml"
+        volume = in_volume*ML_TO_OZ_CONVERSION
+      else
+        volume = in_volume
+      end
     end
 
-    number_of_servings = ((volume*in_abv)/SERVINGS_CONVERSION).round(2)
+    return volume
+  end
+  module_function :calculate_volume
 
+  def calculate_servings(in_abv, in_volume)
+    number_of_servings = ((in_volume*in_abv)/SERVINGS_CONVERSION).round(2)
     return number_of_servings
   end
   module_function :calculate_servings

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,7 +1,13 @@
 <div class="pages">
   <h1>Results</h1>
+
+  <% if @packaging == nil %>
+    <h3>Volume: <%=('%.0f' % @calculated_volume)%> <%=@unit%></h3>
+  <% else %>
+    <h3>Packaging: <%=Constants::DISPLAY_PACKAGING[@packaging]%></h3>
+  <% end %>
+
   <h3>ABV: <%=('%.1f' % @abv)%>%</h3>
-  <h3>Volume: <%=('%.0f' % @volume)%> <%=@unit%></h3>
   <h3>Number of Servings: <%=@number_of_servings%></h3>
 
   <% if @cost != 0 %>

--- a/app/views/homes/new.html.erb
+++ b/app/views/homes/new.html.erb
@@ -4,15 +4,14 @@
 
   <form action="/homes">
 
-
     <h3>Start with selecting your packaging...</h3>
     <div class="input-field">
       <label for="packaging">Packaging</label>
         <select name="packaging" type="text">
           <option value=""></option>
           <option value="750ml">750ml bottle</option>
-          <option value="4-16">4pk of 16 fluid ounnce cans</option>
-          <option value="6-12">6pk of 12 fluid ounnce bottles</option>
+          <option value="4pk-16oz">4-pack of 16 fluid ounnce cans</option>
+          <option value="6pk-12oz">6-pack of 12 fluid ounnce bottles</option>
         </select>
     </div>
 


### PR DESCRIPTION
Added the ability to select a package format in addition to selecting a custom volume.

First pass allows the user to select a 750ml bottle, a 4pk of 16oz cans, or a 6pk of 12oz bottles.

Struggling with the verbage; oz vs fluid ounces, cans vs bottles vs containers/units/vessels.